### PR TITLE
Add Category support

### DIFF
--- a/feedhub/atom.go
+++ b/feedhub/atom.go
@@ -115,11 +115,12 @@ func newAtomEntry(i *Item) *AtomEntry {
 		link_rel = "alternate"
 	}
 	x := &AtomEntry{
-		Title:   i.Title,
-		Links:   []AtomLink{{Href: i.Link.Href, Rel: link_rel, Type: i.Link.Type}},
-		Id:      id,
-		Updated: anyTimeFormat(time.RFC3339, i.Updated, i.Created),
-		Summary: s,
+		Title:    i.Title,
+		Links:    []AtomLink{{Href: i.Link.Href, Rel: link_rel, Type: i.Link.Type}},
+		Id:       id,
+		Updated:  anyTimeFormat(time.RFC3339, i.Updated, i.Created),
+		Summary:  s,
+		Category: i.Category,
 	}
 
 	// if there's a content, assume it's html

--- a/feedhub/feed.go
+++ b/feedhub/feed.go
@@ -37,6 +37,7 @@ type Item struct {
 	Created     time.Time
 	Enclosure   *Enclosure
 	Content     string
+	Category    string // used as first element of tags in json
 }
 
 type Feed struct {

--- a/feedhub/json.go
+++ b/feedhub/json.go
@@ -178,6 +178,9 @@ func newJSONItem(i *Item) *JSONItem {
 	if i.Enclosure != nil && strings.HasPrefix(i.Enclosure.Type, "image/") {
 		item.Image = i.Enclosure.Url
 	}
+	if i.Category != "" {
+		item.Tags = []string{i.Category}
+	}
 
 	return item
 }

--- a/feedhub/rss.go
+++ b/feedhub/rss.go
@@ -98,6 +98,7 @@ func newRssItem(i *Item) *RssItem {
 		Description: i.Description,
 		Guid:        i.Id,
 		PubDate:     anyTimeFormat(time.RFC1123Z, i.Created, i.Updated),
+		Category:    i.Category,
 	}
 	if i.Link != nil {
 		item.Link = i.Link.Href


### PR DESCRIPTION
This PR:

- adds `Category` to the generic feed item
- uses that new field to populate:
    - `Category` on RSS & Atom items
    - the first element of `Tags` on JSON items